### PR TITLE
Implement customer info back

### DIFF
--- a/src/Message/IdealPurchaseRequest.php
+++ b/src/Message/IdealPurchaseRequest.php
@@ -13,6 +13,16 @@ class IdealPurchaseRequest extends PurchaseRequest
     {
         return $this->setParameter('issuer', $value);
     }
+    
+    public function setSepa($value)
+    {
+            return $this->setParameter('cinfo_in_callback', $value);
+    }
+
+    public function getSepa()
+    {
+            return $this->getParameter('cinfo_in_callback');
+    }
 
     /**
      * {@inheritdoc}
@@ -30,6 +40,7 @@ class IdealPurchaseRequest extends PurchaseRequest
             'currency' => $this->getCurrency(),
             'returnurl' => $this->getReturnUrl(),
             'reporturl' => $this->getNotifyUrl(),
+            'cinfo_in_callback' =>$this->getSepa(),
         );
     }
 


### PR DESCRIPTION
If you want to use iDeal in combination with SEPA Incasso, this function will pass cinfo_in_callback flag to TargetPay as specified in https://www.targetpay.com/info/directdebit-docu (Section 4. below). The reporturl will be called with `trxid=0030000794957746&rtlo=107053&status=000000 OK&cname=Naam&cbank=bankrekeningnumer`
